### PR TITLE
Fix Source Files for iOS and Jump to Version 2.0.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -18,8 +18,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 22
-        versionCode 1
-        versionName "1.0"
+        versionCode 2
+        versionName "2.0.1"
     }
     lintOptions {
         abortOnError false

--- a/ios/RNOpenAppSettings.podspec
+++ b/ios/RNOpenAppSettings.podspec
@@ -3,21 +3,15 @@ Pod::Spec.new do |s|
   s.name         = "RNOpenAppSettings"
   s.version      = "1.0.0"
   s.summary      = "RNOpenAppSettings"
-  s.description  = <<-DESC
-                  RNOpenAppSettings
-                   DESC
-  s.homepage     = ""
+  s.description  = "React Native module exposing native application settings"
   s.license      = "MIT"
-  # s.license      = { :type => "MIT", :file => "FILE_LICENSE" }
-  s.author             = { "author" => "author@domain.cn" }
+  s.author       = { "author" => "author@domain.cn" }
   s.homepage     = "https://github.com/KrazyLabs/react-native-app-settings"
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/KrazyLabs/react-native-app-settings.git", :tag => "master" }
-  s.source_files  = "RNOpenAppSettings/**/*.{h,m}"
+  s.source_files = "*.{h,m}"
   s.requires_arc = true
 
-
   s.dependency "React"
-  #s.dependency "others"
 
 end

--- a/ios/RNOpenAppSettings.podspec
+++ b/ios/RNOpenAppSettings.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNOpenAppSettings"
-  s.version      = "1.0.0"
+  s.version      = "2.0.1"
   s.summary      = "RNOpenAppSettings"
   s.description  = "React Native module exposing native application settings"
   s.license      = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-app-settings",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cross-Platform React Native module exposing native application settings.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR fixes how the .h and .m files for iOS were linked to a project using cocoapod as a package dependency.

Also this is jumping to the version 2.0.1 for all the platforms
A `npm publish` is needed in order to update properly all the dependencies. This is also mention here

#4 

Thanks in advance!