### PR TITLE
Update SdkVersion and buildToolsVersion to 26.x.x

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,8 +12,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16


### PR DESCRIPTION
Newer versions of react-native require more than version 25 - this lib is currently on 23. Have tested this with our local builds and works fine for react-native 0.56.