### PR TITLE
added mavenCentral() for gradle builds

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,7 @@
 
 buildscript {
     repositories {
+        mavenCentral()
         jcenter()
     }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@
 buildscript {
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     dependencies {


### PR DESCRIPTION
As jCenter is shutting down so adding mavenCentral() so that gradle builds fail